### PR TITLE
Add support for 100+ LLMs - Anyscale, vertexai, ollama, perplexity, together ai, palm, openrouter 

### DIFF
--- a/llmperf.py
+++ b/llmperf.py
@@ -1,6 +1,6 @@
 import argparse
 from collections import defaultdict
-import ray, openai
+import ray, openai, litellm
 from num2words import num2words
 import time, os, sys, re, json, datetime
 import random
@@ -114,7 +114,7 @@ def validate(ep_config, sample_lines):
         ]
         try:
             st = time.time()
-            response = openai.ChatCompletion.create(
+            response = litellm.completion(
                 model=ep_config["model"],
                 messages=messages,
                 api_key=ep_config["api_key"],

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 openai
+litellm
 num2words
 python_dotenv
 pandas


### PR DESCRIPTION
This PR adds support for the above mentioned LLMs using LiteLLM https://github.com/BerriAI/litellm/ 
LiteLLM is a lightweight package to simplify LLM API calls - use any llm as a drop in replacement for gpt-3.5-turbo. 


Example
```python
from litellm import completion

## set ENV variables
os.environ["OPENAI_API_KEY"] = "openai key"
os.environ["COHERE_API_KEY"] = "cohere key"

messages = [{ "content": "Hello, how are you?","role": "user"}]

# openai call
response = completion(model="gpt-3.5-turbo", messages=messages)

# cohere call
response = completion(model="command-nightly", messages)

# anthropic call
response = completion(model="claude-instant-1", messages=messages)
```