### PR TITLE
Fixed URL by adding version V1 prefix to OpenAI LLMPerf client

### DIFF
--- a/src/llmperf/ray_clients/openai_chat_completions_client.py
+++ b/src/llmperf/ray_clients/openai_chat_completions_client.py
@@ -58,7 +58,7 @@ class OpenAIChatCompletionsClient(LLMClient):
             raise ValueError("No host provided.")
         if not address.endswith("/"):
             address = address + "/"
-        address += "chat/completions"
+        address += "v1/chat/completions"
         try:
             with requests.post(
                 address,


### PR DESCRIPTION
* Added v1 to URL
* Example: https://x.x.x.x/v1/chat/completions
* Complies now with OpenAI and vLLM OpenAI server
* See https://platform.openai.com/docs/api-reference/authentication