### PR TITLE
Added Azure OpenAI endpoint support

### DIFF
--- a/src/llmperf/ray_clients/openai_chat_completions_client.py
+++ b/src/llmperf/ray_clients/openai_chat_completions_client.py
@@ -59,6 +59,12 @@ class OpenAIChatCompletionsClient(LLMClient):
         if not address.endswith("/"):
             address = address + "/"
         address += "chat/completions"
+        if "azure"in address:
+            api_version = os.environ.get("OPENAI_API_VERSION")
+            if not api_version:
+                raise ValueError("the environment variable OPENAI_API_VERSION must be set for Azure OpenAI service.")
+            address = f"{address}?api-version={api_version}"
+            headers = {"api-key": key}  # replace with Authorization: Bearer
         try:
             with requests.post(
                 address,


### PR DESCRIPTION
Added Azure OpenAI endpoint support. For Azure OpenAI, users need to specify `OPENAI_API_VERSION` and update the header to `api-key: <key>` instead of `Authorization: Bearer <token>`

Reference: https://learn.microsoft.com/en-us/azure/ai-services/openai/reference#chat-completions