### PR TITLE
Improve benchmark tput by moving prompt preparation outside of loop

### DIFF
--- a/src/llmperf/utils.py
+++ b/src/llmperf/utils.py
@@ -60,6 +60,8 @@ def randomly_sample_sonnet_lines_prompt(
     prompt_tokens_mean: int = 550,
     prompt_tokens_stddev: int = 250,
     expect_output_tokens: int = 150,
+    tokenizer = LlamaTokenizerFast.from_pretrained(
+        "hf-internal-testing/llama-tokenizer")
 ) -> Tuple[str, int]:
     """Generate a prompt that randomly samples lines from a the shakespeare sonnet at sonnet.txt.
 
@@ -79,10 +81,6 @@ def randomly_sample_sonnet_lines_prompt(
     Returns:
         A tuple of the prompt and the length of the prompt.
     """
-
-    tokenizer = LlamaTokenizerFast.from_pretrained(
-        "hf-internal-testing/llama-tokenizer"
-    )
 
     get_token_length = lambda text: len(tokenizer.encode(text))
 


### PR DESCRIPTION
Moved the prompt making call to randomly_sample_sonnet_lines_prompt outside of load request send loop so that the send loop can generate load to the server faster. Otherwise there's an artificial delay due to making the next prompt which slows down the benchmark throughput/sec. 
Also changed tokenizer instantiation to just once outside the prompt generation loop to speed up the overall test.
After this change I've seen up to 2x improvement in server achieved throughput in some small workloads. This change will allow better measurement of true server throughput.