### PR TITLE
fix: subsequent requests cannot be sent until 'num_concurrent_requests' requests have all finished in non-block mode

### DIFF
--- a/src/llmperf/requests_launcher.py
+++ b/src/llmperf/requests_launcher.py
@@ -40,6 +40,7 @@ class RequestsLauncher:
         if not block:
             while self._llm_client_pool.has_next():
                 results.append(self._llm_client_pool.get_next_unordered())
+                return results
         else:
             while not self._llm_client_pool.has_next():
                 pass


### PR DESCRIPTION
## issues
https://github.com/ray-project/llmperf/issues/43
https://github.com/ray-project/llmperf/issues/56

## Summary
- subsequent requests cannot be sent until whole requests have all finished even in non-block mode.
- `get_next_ready` function should be fixed to return its result as soon as possible in non-block mode.