### PR TITLE
Adjust chat completion request message order

### DIFF
--- a/src/llmperf/ray_clients/openai_chat_completions_client.py
+++ b/src/llmperf/ray_clients/openai_chat_completions_client.py
@@ -20,8 +20,8 @@ class OpenAIChatCompletionsClient(LLMClient):
         prompt, prompt_len = prompt
 
         message = [
-            {"role": "system", "content": ""},
             {"role": "user", "content": prompt},
+            {"role": "system", "content": ""},
         ]
         model = request_config.model
         body = {


### PR DESCRIPTION
I noticed when attempting to benchmark google/gemma-2-9b-it on vllm that the order of the "user" and "system" roles in the message object is relevant, and starting with "system" causes the inference server to reject the request with HTTP 400.

This small patch simply reverses the order, which should generally make sense for all other use cases. I've also successfully tested my patch with Gemma 2 and Llama 3.1 model on vllm.