### PR TITLE
Refactor to use `yarl` package for safe URL manipulation

### DIFF
--- a/src/llmperf/models.py
+++ b/src/llmperf/models.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, Optional, Tuple
 from pydantic import BaseModel
 
 

--- a/src/llmperf/ray_clients/openai_chat_completions_client.py
+++ b/src/llmperf/ray_clients/openai_chat_completions_client.py
@@ -5,6 +5,7 @@ from typing import Any, Dict
 
 import ray
 import requests
+import yarl
 
 from llmperf.ray_llm_client import LLMClient
 from llmperf.models import RequestConfig
@@ -54,14 +55,9 @@ class OpenAIChatCompletionsClient(LLMClient):
         if not key:
             raise ValueError("the environment variable OPENAI_API_KEY must be set.")
         headers = {"Authorization": f"Bearer {key}"}
-        if not address:
-            raise ValueError("No host provided.")
-        if not address.endswith("/"):
-            address = address + "/"
-        address += "chat/completions"
         try:
             with requests.post(
-                address,
+                str(yarl.URL(address).with_path("/chat/completions")),
                 json=body,
                 stream=True,
                 timeout=180,

--- a/src/llmperf/ray_clients/openai_chat_completions_client.py
+++ b/src/llmperf/ray_clients/openai_chat_completions_client.py
@@ -57,7 +57,7 @@ class OpenAIChatCompletionsClient(LLMClient):
         headers = {"Authorization": f"Bearer {key}"}
         try:
             with requests.post(
-                str(yarl.URL(address).with_path("/chat/completions")),
+                yarl.URL(address).with_path("/chat/completions"),
                 json=body,
                 stream=True,
                 timeout=180,


### PR DESCRIPTION
Hello llmperf!

This pull request suggests to use `yarl`, which is already included, to manipulate URL safely.

The change in this pull request, `yarl.URL(address).with_path("/chat/completions")`, will always result in a valid URL, whether the `address` ends with a trailing slash(`/`) or not.

Thanks in advance for your kind review!
